### PR TITLE
Include .gitconfig for work

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -16,3 +16,5 @@
 [user]
 	name = Ryuichi Okumura
 	email = okuryu@okuryu.com
+[includeIf "gitdir:~/work/"]
+  path = ~/.gitconfig-work


### PR DESCRIPTION
If the `~/work/` directory exists, it read .gitconfig configuration for work.
